### PR TITLE
增加cp对象文件所属的上级目录不存在时候先创建对应目录，同时修改copy文件和目录所对应不同的参数

### DIFF
--- a/gitup.sh
+++ b/gitup.sh
@@ -6,6 +6,7 @@ if [ $# -ne 1 ] ; then
 fi
 
 workpath=/root/hequan
+deploy_path=/data/htdocs/
 cd $workpath
 cd irulu
 git checkout master
@@ -21,12 +22,22 @@ do
 	filepath=`dirname ${filename_path}`
 
 	if [ -d $filename_path2 ] ; then
-        /bin/cp -fr $filename_path2 /data0/htdocs/$filepath
+        /bin/cp -fr $filename_path2 $deploy_path$filepath
 	else
 		if [ -d ${filepath} ] ; then
-            /bin/cp -f $filename_path2 /data0/htdocs/$filename_path
-		else
-            /bin/cp -rf `dirname $filename_path2` /data0/htdocs/$filepath
+			if [ ! -d $deploy_path$filepath ] ; then
+				mkdir -pv $deploy_path$filepath
+				if [ $? -ne 0 ] ; then
+					echo "mkdir $deploy_path$filepath failed"
+					exit
+				fi
+			fi
+
+			if [ -f $filename_path ] ; then
+				/bin/cp -f $filename_path $deploy_path$filename_path
+            else
+                /bin/cp -fr $filename_path $dst_project_path$filepath
+            fi		
 		fi
 	fi
 


### PR DESCRIPTION
fixed cp object bug
